### PR TITLE
Remove `pgfarrows`

### DIFF
--- a/slides-setting.tex
+++ b/slides-setting.tex
@@ -30,7 +30,7 @@
 \usepackage{algorithm}
 \algrenewcommand\textproc{\texttt}
 \usepackage{pgfpages}                % allow note printing
-\usepackage{pgf,pgfarrows,pgfnodes,pgfautomata,pgfheaps,pgfshade}
+\usepackage{pgf}
 \usepackage{amsmath}
 \usepackage{newtxtext}               % to use Times font (only for text, but not for math)
 \usepackage{multirow}


### PR DESCRIPTION
This package `pgfarrows` is obsolete. `pgf.sty` will load arrow management automatically.